### PR TITLE
Add debug mode to the metrics script

### DIFF
--- a/test/controllers/mission_control/servers/scripts_controller_test.rb
+++ b/test/controllers/mission_control/servers/scripts_controller_test.rb
@@ -13,7 +13,7 @@ module MissionControl::Servers
       assert_response :success
       assert_match @project.token, @response.body
       assert_match "#!/bin/bash", @response.body
-      assert_match "curl -X POST $endpoint -d $data", @response.body
+      assert_match "curl -X POST \"$endpoint\" -d \"$data\"", @response.body
     end
 
     test "should handle non-existing project" do


### PR DESCRIPTION
Allows to run it with the `--debug` flag to showcase any possible incidence. Otherwise, `curl` will just swallow the errors.